### PR TITLE
Return shape from ObjectType

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ Reference Types
 
 - [object](#object)
   - [pick/omit/partial](#object.pick/omit/partial)
+  - [shape](#object.shape)
 - [record](#record)
 - [array](#array)
 - [tuple](#tuple)
@@ -392,11 +393,9 @@ emptyObjSchema.parse({ key: 'value' }); // => succeeds
 strictEmptyObjSchema.parse({ key: 'value' }); // => throws ValidationError because not expected key: "key"
 
 const personSchema = myzod.object({
-  name: myzod.string().min(2),
-  age: myzod.number({ min: 0 }).nullable(),
+  name: myzod.string(),
 });
-
-type Person = Infer<typeof personSchema>; // => { name: string; age: number | null }
+const shape = personSchema.shape(); // => returns { name: myzod.string() }
 ```
 
 #### object.withPredicate
@@ -409,6 +408,18 @@ const registrationSchema = myzod
     email: z.string().withPredicate(validator.isEmail, 'expected email'),
     password: z.string().min(8),
     confirmedPassword: z.string(),
+  })
+  .withPredicate(value => value.password === value.confirmedPassword, 'password and confirmed do not match');
+```
+
+#### object.shape
+
+You can extract the shape from an ObjectType.
+
+```typescript
+const registrationSchema = myzod
+  .object({
+    email: z.string()
   })
   .withPredicate(value => value.password === value.confirmedPassword, 'password and confirmed do not match');
 ```

--- a/readme.md
+++ b/readme.md
@@ -416,11 +416,10 @@ const registrationSchema = myzod
 You can extract the shape from an ObjectType.
 
 ```typescript
-const registrationSchema = myzod
-  .object({
-    email: z.string()
-  })
-  .withPredicate(value => value.password === value.confirmedPassword, 'password and confirmed do not match');
+const personSchema = myzod.object({
+  name: myzod.string(),
+});
+const shape = personSchema.shape(); // => returns { name: myzod.string() }
 ```
 
 #### object.pick/omit/partial

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,6 @@ Reference Types
 
 - [object](#object)
   - [pick/omit/partial](#object.pick/omit/partial)
-  - [shape](#object.shape)
 - [record](#record)
 - [array](#array)
 - [tuple](#tuple)

--- a/src/types.ts
+++ b/src/types.ts
@@ -733,6 +733,10 @@ export class ObjectType<T extends ObjectShape> extends Type<InferObjectShape<T>>
     return new ObjectType(schema, { allowUnknown: opts?.allowUnknown });
   }
 
+  shape(): T {
+    return Object.assign({}, this.objectShape);
+  }
+
   withPredicate(fn: Predicate<InferObjectShape<T>>['func'], errMsg?: ErrMsg<InferObjectShape<T>>): ObjectType<T> {
     return new ObjectType(this.objectShape, {
       ...this.opts,


### PR DESCRIPTION
This merge request adds a `shape()` method to `ObjectType` returning a copy of the type's `ObjectShape`. This eases the implementation of higher-level wrappers leveraging the object shape.