### PR TITLE
Add option of coerce for EnumType

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -684,9 +684,9 @@ if (colorSchema.check(value)) {
 }
 ```
 
-The enum type also accepts a config object as a second parameter.
+The enum type also accepts an options object as a second parameter.
 
-You can set `coerce` to `'lower'` or  `'upper'` to ignore string casing when calling `check` or `parse`.
+You can set `coerce` to `'lower'` or `'upper'` to ignore string casing when calling `check` or `parse`.
 
 ```typescript
 z.enum(Colors, { coerce: 'lower' });
@@ -696,7 +696,7 @@ if (colorSchema.check(value)) {
 }
 ```
 
-You can also set a default value in the config object.
+You can also set a default value in the options object.
 
 ```typescript
 z.enum(Colors, { defaultValue: 'red' });

--- a/readme.md
+++ b/readme.md
@@ -691,9 +691,8 @@ You can set `coerce` to `'lower'` or `'upper'` to ignore string casing when call
 ```typescript
 z.enum(Colors, { coerce: 'lower' });
 const value: string = 'Red';
-if (colorSchema.check(value)) {
-  // this will pass
-}
+colorSchema.parse(value);
+// this will pass and return a lowercased value
 ```
 
 You can also set a default value in the options object.

--- a/readme.md
+++ b/readme.md
@@ -684,6 +684,24 @@ if (colorSchema.check(value)) {
 }
 ```
 
+The enum type also accepts a config object as a second parameter.
+
+You can set `coerce` to `'lower'` or  `'upper'` to ignore string casing when calling `check` or `parse`.
+
+```typescript
+z.enum(Colors, { coerce: 'lower' });
+const value: string = 'Red';
+if (colorSchema.check(value)) {
+  // this will pass
+}
+```
+
+You can also set a default value in the config object.
+
+```typescript
+z.enum(Colors, { defaultValue: 'red' });
+```
+
 #### Date
 
 methods:

--- a/readme.md
+++ b/readme.md
@@ -692,7 +692,7 @@ You can set `coerce` to `'lower'` or `'upper'` to ignore string casing when call
 z.enum(Colors, { coerce: 'lower' });
 const value: string = 'Red';
 colorSchema.parse(value);
-// this will pass and return a lowercased value
+// parse will return a lowercased value
 ```
 
 You can also set a default value in the options object.

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import {
   BigIntOptions,
   BigIntType,
   StringOptions,
+  EnumOptions,
 } from './types';
 
 export { ValidationError, Type, Infer, keySignature } from './types';
@@ -121,7 +122,7 @@ export function omit<
 
 const undefinedValue = () => new UndefinedType();
 const nullValue = () => new NullType();
-const enumValue = <T>(e: T) => new EnumType(e);
+const enumValue = <T>(e: T, opts?: EnumOptions<T>) => new EnumType(e, opts);
 
 export { undefinedValue as undefined, nullValue as null, enumValue as enum };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1219,16 +1219,7 @@ export class EnumType<T> extends Type<ValueOf<T>> implements Defaultable<ValueOf
     //@ts-ignore
     value: unknown = typeof this.defaultValue === 'function' ? this.defaultValue() : this.defaultValue
   ): ValueOf<T> {
-    let coercedValue = value;
-    if (typeof value === 'string' && this.coerceOpt === 'lower') {
-      coercedValue = value.toLowerCase();
-    } else if (typeof value === 'string' && this.coerceOpt === 'upper') {
-      coercedValue = value.toUpperCase();
-    }
-    if (!this.values.includes(coercedValue)) {
-      throw new ValidationError(`error ${JSON.stringify(value)} not part of enum values`);
-    }
-    return coercedValue as ValueOf<T>;
+    return this.values.includes(value);
   }
   check(value: unknown): value is ValueOf<T> {
     let coercedValue = value;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1219,16 +1219,19 @@ export class EnumType<T> extends Type<ValueOf<T>> implements Defaultable<ValueOf
     //@ts-ignore
     value: unknown = typeof this.defaultValue === 'function' ? this.defaultValue() : this.defaultValue
   ): ValueOf<T> {
-    return this.values.includes(value);
-  }
-  check(value: unknown): value is ValueOf<T> {
     let coercedValue = value;
     if (typeof value === 'string' && this.coerceOpt === 'lower') {
       coercedValue = value.toLowerCase();
     } else if (typeof value === 'string' && this.coerceOpt === 'upper') {
       coercedValue = value.toUpperCase();
     }
-    return this.values.includes(coercedValue);
+    if (!this.values.includes(coercedValue)) {
+      throw new ValidationError(`error ${JSON.stringify(value)} not part of enum values`);
+    }
+    return coercedValue as ValueOf<T>;
+  }
+  check(value: unknown): value is ValueOf<T> {
+    return this.values.includes(value);
   }
   and<K extends AnyType>(schema: K): IntersectionType<this, K> {
     return new IntersectionType(this, schema);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1231,7 +1231,13 @@ export class EnumType<T> extends Type<ValueOf<T>> implements Defaultable<ValueOf
     return coercedValue as ValueOf<T>;
   }
   check(value: unknown): value is ValueOf<T> {
-    return this.values.includes(value);
+    let coercedValue = value;
+    if (typeof value === 'string' && this.coerceOpt === 'lower') {
+      coercedValue = value.toLowerCase();
+    } else if (typeof value === 'string' && this.coerceOpt === 'upper') {
+      coercedValue = value.toUpperCase();
+    }
+    return this.values.includes(coercedValue);
   }
   and<K extends AnyType>(schema: K): IntersectionType<this, K> {
     return new IntersectionType(this, schema);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1198,24 +1198,37 @@ export class IntersectionType<T extends AnyType, K extends AnyType> extends Type
 }
 
 type ValueOf<T> = T[keyof T];
+type EnumCoerceOptions = 'upper' | 'lower';
+export type EnumOptions<T> = {
+  coerce?: EnumCoerceOptions;
+  defaultValue?: ValueOf<T> | (() => ValueOf<T>);
+};
 
 export class EnumType<T> extends Type<ValueOf<T>> implements Defaultable<ValueOf<T>> {
   private values: any[];
   private readonly defaultValue?: ValueOf<T> | (() => ValueOf<T>);
-  constructor(private readonly enumeration: T, defaultValue?: ValueOf<T> | (() => ValueOf<T>)) {
+  private readonly coerceOpt?: EnumCoerceOptions;
+  constructor(private readonly enumeration: T, opts: EnumOptions<T> = {}) {
     super();
     this.values = Object.values(enumeration);
-    this.defaultValue = defaultValue;
+    this.coerceOpt = opts.coerce;
+    this.defaultValue = opts.defaultValue;
     (this as any)[coercionTypeSymbol] = this.defaultValue !== undefined;
   }
   parse(
     //@ts-ignore
     value: unknown = typeof this.defaultValue === 'function' ? this.defaultValue() : this.defaultValue
   ): ValueOf<T> {
-    if (!this.values.includes(value)) {
+    let coercedValue = value;
+    if (typeof value === 'string' && this.coerceOpt === 'lower') {
+      coercedValue = value.toLowerCase();
+    } else if (typeof value === 'string' && this.coerceOpt === 'upper') {
+      coercedValue = value.toUpperCase();
+    }
+    if (!this.values.includes(coercedValue)) {
       throw new ValidationError(`error ${JSON.stringify(value)} not part of enum values`);
     }
-    return value as ValueOf<T>;
+    return coercedValue as ValueOf<T>;
   }
   check(value: unknown): value is ValueOf<T> {
     return this.values.includes(value);
@@ -1223,8 +1236,8 @@ export class EnumType<T> extends Type<ValueOf<T>> implements Defaultable<ValueOf
   and<K extends AnyType>(schema: K): IntersectionType<this, K> {
     return new IntersectionType(this, schema);
   }
-  default(value: ValueOf<T> | (() => ValueOf<T>)): EnumType<T> {
-    return new EnumType(this.enumeration, value);
+  default(defaultValue: ValueOf<T> | (() => ValueOf<T>)): EnumType<T> {
+    return new EnumType(this.enumeration, { defaultValue });
   }
 }
 

--- a/test/parsing.test.ts
+++ b/test/parsing.test.ts
@@ -1573,6 +1573,18 @@ describe('Zod Parsing', () => {
       assert.equal(defaultedSchema.parse(undefined), Colors.green);
       assert.ok((defaultedSchema as any)[coercionTypeSymbol]);
     });
+
+    it('should be case sensitive for string enum', () => {
+      const err = catchError(schema.parse.bind(schema))('RED');
+      assert.equal(err instanceof z.ValidationError, true);
+      assert.equal(err.message, 'error "RED" not part of enum values');
+    });
+
+    it('should be case insensitive for coerced string enum', () => {
+      const coerceSchema = z.enum(Colors, { coerce: 'lower' });
+      assert.equal(coerceSchema.parse('RED'), Colors.red);
+      assert.ok(!(coerceSchema as any)[coercionTypeSymbol]);
+    });
   });
 
   describe('partial parsing', () => {


### PR DESCRIPTION
I have had to do some hacky workarounds to handle string case sensitivity when parsing an EnumType so I created this and was hoping to get it adopted. If this feature could cause problems in other places or if there is something I should change please let me know.
Thanks!