### PR TITLE
Fix unique-array length checks

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1203,16 +1203,16 @@ export class ArrayType<T extends AnyType>
 
     let self: ArrayType<T> = this;
     if (typeof opts.length !== 'undefined') {
-      self = this.length(opts.length);
+      self = self.length(opts.length);
     }
     if (typeof opts.min !== 'undefined') {
-      self = this.min(opts.min);
+      self = self.min(opts.min);
     }
     if (typeof opts.max !== 'undefined') {
-      self = this.max(opts.max);
+      self = self.max(opts.max);
     }
     if (opts.unique === true) {
-      self = this.unique();
+      self = self.unique();
     }
     return self;
   }

--- a/test/parsing.test.ts
+++ b/test/parsing.test.ts
@@ -1322,6 +1322,13 @@ describe('Zod Parsing', () => {
         .map(f => f[0]);
       assert.equal(strArrayFields[0], 'two');
     });
+
+    it('should fail if unique array does not meet minimum length', () => {
+      const schema = z.array(z.number(), {unique: true, min: 1});
+      const err = catchError(schema.parse.bind(schema))([]);
+      assert.equal(err instanceof z.ValidationError, true);
+      assert.equal(err.message, 'expected array to have length greater than or equal to 1 but got 0');
+    });
   });
 
   describe('union parsing', () => {


### PR DESCRIPTION
Encountered a bug with array's `unique` and `min`, so I set up a test case to demonstrate it.

I debugged it and posted the fix as well, and approved by my employer for release.