### PR TITLE
Fix broken links on the index of the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,12 +60,12 @@ const person: Person = personSchema.parse({ ... });
 Type Root
 
 - [Type<T>](#type)
-  - [parse](#type.parse)
-  - [try](#type.try)
-  - [and](#type.and)
-  - [or](#type.or)
-  - [optional](#type.optional)
-  - [nullable](#type.nullable)
+  - [parse](#typeparse)
+  - [try](#typetry)
+  - [and](#typeand)
+  - [or](#typeor)
+  - [optional](#typeoptional)
+  - [nullable](#typenullable)
 
 Primitive Types
 


### PR DESCRIPTION
Links to `type.parse`, `type.try`, `type.and`, `type.or`, `type.optional` and `type.nullable` were broken and not linking to the correct sections. This PR fixes this issue.