### PR TITLE
improve performance when building large schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myzod",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "myzod",
-      "version": "1.10.2",
+      "version": "1.11.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { IntersectionType } from './types';
 import {
+  keySignature,
   ValidationError,
   Type,
   StringType,
@@ -40,6 +41,7 @@ import {
 } from './types';
 
 export {
+  keySignature,
   ValidationError,
   Type,
   Infer,
@@ -62,9 +64,6 @@ export {
   UnionType,
   IntersectionType,
 } from './types';
-
-const keySignature = Symbol('keySignature');
-export { keySignature };
 
 export const string = (opts?: StringOptions) => new StringType(opts);
 export const boolean = () => new BooleanType();


### PR DESCRIPTION
We have a very large schema and we've noticed the app startup spends over 500ms just constructing the schema (not parsing).  Traced the culprit to the deep clone that is performed anytime a schema is modified (via `withPredicate` or `allowUnknownType`, etc).

Changed implementation to use shallow clone instead (no need to clone all of the nested objects).
Also clone method to create cloned object with correct prototype instead of mutating prototype after creation (which is a documented performance issue).

Also fixed a circular dependency between `index.ts` and `type.ts`.;

![image](https://github.com/user-attachments/assets/8517facd-6085-467e-82a0-fc3434623a8f)
